### PR TITLE
Fix #33

### DIFF
--- a/src/lib/ui.py
+++ b/src/lib/ui.py
@@ -530,7 +530,7 @@ class PasswordLabel(EventBox):
             menu.append(menuitem)
 
             menu.show_all()
-            menu.popup(None, None, None, data.button, data.time)
+            menu.popup(None, None, None, data, data.button, data.time)
 
             return True
 


### PR DESCRIPTION
Fixes crash when asking for context menu on the Password field in the right-hand pane.