### PR TITLE
revelation: Use error class instead of error dialog for failed searches

### DIFF
--- a/src/revelation.py
+++ b/src/revelation.py
@@ -1044,14 +1044,16 @@ class Revelation(ui.App):
         "Searches for an entry"
 
         match = self.entrysearch.find(string, entrytype, self.tree.get_active(), direction)
+        context = self.searchbar.entry.get_style_context()
 
         if match != None:
             self.tree.select(match)
             self.statusbar.set_status(_('Match found for \'%s\'') % string)
+            context.remove_class(Gtk.STYLE_CLASS_ERROR)
 
         else:
             self.statusbar.set_status(_('No match found for \'%s\'') % string)
-            dialog.Error(parent.window, _('No match found'), _('The string \'%s\' does not match any entries. Try searching for a different phrase.') % string).run()
+            context.add_class(Gtk.STYLE_CLASS_ERROR)
 
 
     def __file_autosave(self):


### PR DESCRIPTION
Currently, when there is no match revelation opens a dialog indicating an error, an requiring closing it.

An alternative approach is to use a different style when an error (match not found) as a visual cue for the user. See the screenshot:

![Screenshot from 2020-09-21 13-52-48](https://user-images.githubusercontent.com/877181/93800193-99522900-fc16-11ea-867f-90ed9101b816.png)

That reduces one dialog, and paves the way to enable search-as-you-type in the future.