### PR TITLE
ui: Remove option for detachable menu

### DIFF
--- a/src/lib/ui.py
+++ b/src/lib/ui.py
@@ -1440,14 +1440,8 @@ class App(Gtk.Application):
             self.toolbars[name].show()
 
 
-    def add_toolbar(self, toolbar, name, band, detachable):
+    def add_toolbar(self, toolbar, name, band):
         "Adds a toolbar"
-
-        # TODO: This is not working correctly yet.
-        if detachable:
-            handlebox = Gtk.HandleBox()
-            handlebox.add(toolbar)
-            toolbar = handlebox
 
         self.toolbars[name] = toolbar
         self.main_vbox.pack_start(toolbar, False, True, 0)

--- a/src/revelation.py
+++ b/src/revelation.py
@@ -474,19 +474,13 @@ class Revelation(ui.App):
 
         self.toolbar=toolbar
         self.toolbar.connect("popup-context-menu", lambda w,x,y,b: True)
-        self.add_toolbar(toolbar, "toolbar", 1, False)
+        self.add_toolbar(toolbar, "toolbar", 1)
 
         self.statusbar = ui.Statusbar()
         self.main_vbox.pack_end(self.statusbar, False, True, 0)
 
-        try:
-            detachable = Gio.Settings.new("org.gnome.desktop.interface").get_boolean("toolbar-detachable")
-
-        except config.ConfigError:
-            detachable = False
-
         self.searchbar = ui.Searchbar()
-        self.add_toolbar(self.searchbar, "searchbar", 2, detachable)
+        self.add_toolbar(self.searchbar, "searchbar", 2)
 
         # set up main application widgets
         self.tree = ui.EntryTree(self.entrystore)


### PR DESCRIPTION
Having a detachable menu was a thing in Gnome 2, but not in Gnome 3. We make the Revelation more consistent with the rest of applications.

Additionally, GtkHandleBox was deprecated on Gtk 3.4.