### PR TITLE
Add Keyboard Shorcut window

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,12 @@ AX_PYTHON_GI(Pango, 1.0)
 AX_PYTHON_GI(Gdk, 3.0)
 RVL_PYTHON_MODULE(pwquality, yes)
 
+AC_ARG_VAR([GLIB_COMPILE_RESOURCES],[the glib-compile-resources programme])
+AC_PATH_PROG([GLIB_COMPILE_RESOURCES],[glib-compile-resources],[])
+if test -z "$GLIB_COMPILE_RESOURCES"; then
+  AC_MSG_ERROR([glib-compile-resources not found])
+fi
+
 dnl output files
 AC_CONFIG_FILES([
 	Makefile

--- a/data/ui/Makefile.am
+++ b/data/ui/Makefile.am
@@ -6,5 +6,10 @@
 #
 
 uidir		= $(pkgdatadir)/ui
-dist_ui_DATA	= menubar.ui popup-tree.ui toolbar.ui
+dist_ui_DATA	= menubar.ui popup-tree.ui toolbar.ui revelation.gresource
 
+revelation.gresource: revelation.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies $(srcdir)/revelation.gresource.xml)
+	$(GLIB_COMPILE_RESOURCES) --target $@ --sourcedir=$(srcdir) --generate $< 
+
+EXTRA_DIST  = revelation.gresource.xml help-overlay.ui
+CLEANFILES  = revelation.gresource

--- a/data/ui/help-overlay.ui
+++ b/data/ui/help-overlay.ui
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkShortcutsWindow" id="help_overlay">
+    <property name="modal">True</property>
+    <child>
+      <object class="GtkShortcutsSection">
+        <property name="visible">True</property>
+        <property name="section-name">shortcuts</property>
+        <property name="max-height">13</property>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">Password files</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Create a new password file</property>
+                <property name="accelerator">&lt;Primary&gt;N</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Open a password file</property>
+                <property name="accelerator">&lt;Primary&gt;O</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Save a password file</property>
+                <property name="accelerator">&lt;Primary&gt;S</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes"
+								context="shortcut window">Close the current password file</property>
+                <property name="accelerator">&lt;Primary&gt;W</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">Window</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Lock the access to the content</property>
+                <property name="accelerator">&lt;Primary&gt;L</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit the application</property>
+                <property name="accelerator">&lt;Primary&gt;Q</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Toggle show passwords</property>
+                <property name="accelerator">&lt;Primary&gt;P</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">Password entries</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Add a new password entry</property>
+                <property name="accelerator">&lt;Primary&gt;Insert</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes"
+								context="shortcut window">Add a new folder for password entries</property>
+                <property name="accelerator">&lt;Shift&gt;&lt;Primary&gt;Insert</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Edit current entry</property>
+                <property name="accelerator">&lt;Primary&gt;Return</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Delete current entry</property>
+                <property name="accelerator">&lt;Primary&gt;Delete</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Copy password</property>
+                <property name="accelerator">&lt;Shift&gt;&lt;Primary&gt;C</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">Selection</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Select all entries</property>
+                <property name="accelerator">&lt;Primary&gt;A</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Deselect all entries</property>
+                <property name="accelerator">&lt;Shift&gt;&lt;Primary&gt;A</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">Finding password entry</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Show the search bar</property>
+                <property name="accelerator">&lt;Primary&gt;F</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Hide the search bar</property>
+                <property name="accelerator">Escape</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Find the next match</property>
+                <property name="accelerator">&lt;Primary&gt;G</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Find the previous match</property>
+                <property name="accelerator">&lt;Primary&gt;&lt;shift&gt;G</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">True</property>
+            <property name="title" translatable="yes" context="shortcut window">General</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Keyboard shortcuts</property>
+                <property name="accelerator">&lt;Primary&gt;question &lt;Primary&gt;F1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit</property>
+                <property name="accelerator">&lt;Primary&gt;Q</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/data/ui/menubar.ui
+++ b/data/ui/menubar.ui
@@ -265,6 +265,10 @@
           <attribute name="tooltip">About this application</attribute>
           <attribute name="icon">help-about</attribute>
         </item>
+        <item>
+          <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+          <attribute name="action">win.show-help-overlay</attribute>
+        </item>
       </section>
     </submenu>
   </menu>

--- a/data/ui/revelation.gresource.xml
+++ b/data/ui/revelation.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/info/olasagasti/revelation">
+    <file alias="gtk/help-overlay.ui" preprocess="xml-stripblanks">help-overlay.ui</file>
+  </gresource>
+</gresources>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,7 @@ src/lib/util.py
 src/lib/datahandler/xhtml.py
 data/info.olasagasti.revelation.appdata.xml.in
 data/mime/info.olasagasti.revelation.desktop.in
+data/ui/help-overlay.ui
 data/ui/menubar.ui
 data/ui/popup-tree.ui
 data/ui/toolbar.ui

--- a/src/revelation.py
+++ b/src/revelation.py
@@ -48,6 +48,10 @@ class Revelation(ui.App):
         ui.App.__init__(self, config.APPNAME)
         self.window = None
 
+        resource_path = os.path.join(config.DIR_UI + '/revelation.gresource')
+        resource = Gio.Resource.load(resource_path)
+        resource._register()
+
     def do_startup(self):
         Gtk.Application.do_startup(self)
         if not self.window:


### PR DESCRIPTION
Added a basic GtkShortcutsWindow with the corresponding rules to build it.

It uses GResources (as I think we should move the other UI elements), and the name conventions to reduce the code (see https://developer.gnome.org/gtk3/stable/GtkApplication.html#GtkApplication.description for an explanation).

Fixes #39