### PR TITLE
Add requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyGObject
+pycryptodome
+pwquality


### PR DESCRIPTION
Useful for people to run, for example,
```
   pip3 install -r requirements.txt`
```
Also, for keep track of the changes in the dependencies on
GitHub.