### PR TITLE
Porting to meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To build revelation first `cd` to a suitable location and run:
 git clone https://github.com/mikelolasagasti/revelation.git
 ```
 
+### Build with autotools
 Navigate to the directory where revelation source has been downloaded
 and type these commands:
 
@@ -47,6 +48,34 @@ cd revelation
 ./configure #by default it will be /usr/local
 make
 sudo make install
+```
+
+### Build with Meson
+
+Navigate to the directory where revelation source has been downloaded
+and type these commands:
+
+```sh
+$ cd revelation
+$ meson configure --prefix=$HOME/install _build
+$ cd _build
+$ ninja install
+```
+
+Meson will build revelation in the `_build` directory, and install it in
+`install` in your home directory. You can choose whatever prefix you like.
+
+Because the installation directory is non-standard, to run revelation you
+will have to define some environment variables. In this example:
+
+```sh
+$ export XDG_DATA_DIRS=$HOME/install/share:$XDG_DATA_DIRS
+$ export PYTHONPATH=$HOME/install/lib/python3.8/site-packages
+```
+
+and then run revelation:
+```
+$ $HOME/bin/revelation
 ```
 
 [revelation-logo]: data/icons/scalable/info.olasagasti.revelation.svg

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,0 +1,40 @@
+# Application icons
+apps_icons = [
+  ['16x16', 'info.olasagasti.revelation.png'],
+  ['24x24', 'info.olasagasti.revelation.png'],
+  ['32x32', 'info.olasagasti.revelation.png'],
+  ['48x48', 'info.olasagasti.revelation.png'],
+  ['128x128', 'info.olasagasti.revelation.png'],
+  ['256x256', 'info.olasagasti.revelation.png'],
+  ['scalable', 'info.olasagasti.revelation.svg'],
+]
+
+foreach icon: apps_icons
+  install_data(
+    join_paths(icon[0], icon[1]),
+    install_dir: join_paths(rvl_datadir, 'icons', 'hicolor', icon[0], 'apps'),
+  )
+endforeach
+
+# Mime icons
+install_data(
+  join_paths('48x48', 'gnome-mime-application-x-revelation.png'),
+  install_dir: join_paths(rvl_pkgdatadir, 'icons', 'hicolor', '48x48', 'mimetypes'),
+)
+
+# Actions icons
+actions = [
+  'document-export.svg',
+  'document-import.svg',
+  'object-locked.svg',
+  'password-change.svg',
+  'password-check.svg',
+  'password-generate.svg',
+]
+
+foreach action: actions
+  install_data(
+    join_paths('scalable', action),
+    install_dir: join_paths(rvl_pkgdatadir, 'icons', 'hicolor', 'scalable', 'actions'),
+  )
+endforeach

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,79 @@
+subdir('icons')
+
+# Compile the resources
+resource_data = files(
+  'ui/help-overlay.ui',
+  'ui/menubar.ui',
+  'ui/popup-tree.ui',
+)
+
+gnome.compile_resources(
+  rvl_name,
+  rvl_name + '.gresource.xml',
+  gresource_bundle: true,
+  source_dir: meson.current_build_dir(),
+  install_dir: rvl_pkgdatadir,
+  install: true,
+  dependencies: resource_data,
+)
+
+# Install the schema file
+install_data(
+  rvl_namespace + '.gschema.xml',
+  install_dir: join_paths(rvl_datadir, 'glib-2.0', 'schemas')
+)
+
+# Install the mime file
+install_data(
+  rvl_name + '.xml',
+  install_dir: join_paths(rvl_datadir, 'mime', 'packages')
+)
+
+# Merge the translations with the desktop file
+desktop_conf = configuration_data()
+desktop_conf.set('icon', rvl_namespace)
+i18n.merge_file(
+  type: 'desktop',
+  input: configure_file(
+    output: rvl_namespace + '.desktop.in',
+    input: rvl_namespace + '.desktop.in.in',
+    configuration: desktop_conf),
+  output: rvl_namespace + '.desktop',
+  po_dir: join_paths(meson.source_root(), 'po'),
+  install: true,
+  install_dir: join_paths(rvl_datadir, 'applications')
+)
+
+# Validate the desktop file
+desktop_file_validate = find_program('desktop-file-validate', required:false)
+if desktop_file_validate.found()
+  test (
+    'Validate desktop file',
+    desktop_file_validate,
+    args: join_paths(meson.current_build_dir (), rvl_namespace + '.desktop')
+  )
+endif
+
+appdata = rvl_namespace + '.appdata.xml'
+rvl_appstreamdir = join_paths(rvl_datadir, 'metainfo')
+
+# Merge the translations with the appdata file
+i18n.merge_file(
+  appdata,
+  input: appdata + '.in',
+  output: appdata,
+  po_dir: join_paths(meson.source_root(), 'po'),
+  install: true,
+  install_dir: rvl_appstreamdir,
+)
+
+# Validate the appdata file
+appstream_util = find_program('appstream-util', required: false)
+if appstream_util.found()
+  test (
+    'Validate appdata file',
+    appstream_util,
+    args: ['validate-relax', join_paths(meson.current_build_dir (),
+                                        rvl_namespace + '.appdata.xml')]
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,45 @@
+project('revelation',
+    version : '0.5.3',
+    meson_version: '>= 0.51.0'
+)
+
+# Importing modules
+gnome = import('gnome')
+i18n = import('i18n')
+python = import('python')
+
+# Module objects
+py_installation = python.find_installation('python3',
+  modules: ['Cryptodome',
+            'pwquality'] )
+
+# Dependencies
+dependency('gobject-introspection-1.0', version: '>= 1.35.0')
+dependency('gtk+-3.0', version: '>= 3.22')
+dependency('glib-2.0')
+dependency('pygobject-3.0', version: '>= 3.29.1')
+
+rvl_name = meson.project_name().to_lower()
+rvl_namespace = 'info.olasagasti.revelation'
+rvl_datadir = join_paths(get_option('prefix'), get_option('datadir'))
+rvl_appstreamdir = join_paths(rvl_datadir, 'metainfo')
+rvl_pkgdatadir = join_paths(rvl_datadir, rvl_name)
+rvl_version = meson.project_version()
+
+bindir = join_paths(get_option('prefix'), get_option('bindir'))
+libdir = join_paths(py_installation.get_install_dir(), rvl_name)
+
+subdir('src')
+subdir('data')
+subdir('po')
+
+meson.add_install_script('meson_post_install.py')
+
+output = '\n' + meson.project_name() + ' ' + rvl_version + ' configure summary\n'
+output += '============================\n\n'
+output += 'pythondir.: ' + libdir + '\n'
+output += 'bindir....: ' + bindir + '\n'
+output += 'datadir...: ' + rvl_datadir + '\n'
+output += 'pkgdatadir: ' + rvl_pkgdatadir
+message(output)
+

--- a/meson_post_conf.py
+++ b/meson_post_conf.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+build_root = os.environ.get('MESON_BUILD_ROOT')
+source_root = os.environ.get('MESON_SOURCE_ROOT')
+
+print('Install schemas in build dir…')
+
+source_datadir = os.path.join(source_root, 'data')
+source_file = os.path.join(source_datadir, 'gschemas.compiled')
+targetdir = os.path.join(build_root, 'data', 'glib-2.0', 'schemas')
+
+subprocess.call(['glib-compile-schemas', source_datadir])
+subprocess.call(['mkdir', '-p', targetdir])
+subprocess.call(['mv', source, targetdir])

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+prefix = os.environ.get('MESON_INSTALL_PREFIX', '/usr/local')
+datadir = os.path.join(prefix, 'share')
+
+# Packaging tools define DESTDIR and this isn't needed for them
+if 'DESTDIR' not in os.environ:
+    print('Updating icon cache…')
+    icon_cache_dir = os.path.join(datadir, 'icons', 'hicolor')
+    subprocess.call(['gtk-update-icon-cache', '-qtf', icon_cache_dir])
+    icon_cache_dir = os.path.join(datadir, 'revelation', 'icons', 'hicolor')
+    subprocess.call(['gtk-update-icon-cache', '-qtf', icon_cache_dir])
+
+    print("Compiling the schema…")
+    schemas_dir = os.path.join(datadir, 'glib-2.0/schemas')
+    subprocess.call(['glib-compile-schemas', schemas_dir])
+
+    print('Updating desktop database…')
+    desktop_database_dir = os.path.join(datadir, 'applications')
+    subprocess.call(['update-desktop-database', '-q', desktop_database_dir])
+
+    print("Update mime database…")
+    mime_dir = os.path.join(datadir, 'mime')
+    #subprocess.call(['mkdir', '-p', mime_dir])
+    subprocess.call(['update-mime-database', '-n', mime_dir])

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,1 @@
+i18n.gettext(rvl_name, preset:'glib')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,36 @@
+install_data(
+  'revelation.py',
+  rename: 'revelation',
+  install_mode: 'rwxr-xr-x',
+  install_dir: bindir,
+)
+
+install_subdir(
+  'lib',
+  install_dir: libdir,
+  strip_directory: true,
+  exclude_files: ['Makefile.am', 'Makefile.in',
+                  'datahandler/Makefile.am', 'datahandler/Makefile.in',
+                  'config.py.in']
+)
+
+install_subdir(
+  'bundle',
+  install_dir: libdir,
+  strip_directory: false,
+  exclude_files: ['Makefile.am', 'Makefile.in']
+)
+
+config_conf = configuration_data()
+config_conf.set('pkgdatadir', rvl_pkgdatadir)
+config_conf.set('datadir', rvl_datadir)
+config_conf.set('PACKAGE', rvl_name)
+config_conf.set('VERSION', rvl_version)
+
+configure_file(
+  input: 'lib/config.py.in',
+  output: 'config.py',
+  install: true,
+  install_dir: libdir,
+  configuration: config_conf,
+)


### PR DESCRIPTION
This branch add supports for Meson build system. This PR is on top of  #54, so it is only one commit (https://github.com/mikelolasagasti/revelation/pull/55/commits/cca03359db1434fed73d8771532317859744966b)

One can test it as:

```sh
$ meson configure _build
$ cd _build
$ ninja
```

To create the tarball (inside the build directory):

```sh
$ ninja dist
```

I usually build with a prefix that is in my user account. But that is up to every user. It works fine on
Gnome builder once one sets up the following variables: `XDG_DATA_DIRS` and `PYTHONPATH`.