### PR TITLE
Fixed desktop categories

### DIFF
--- a/data/info.olasagasti.revelation.desktop.in.in
+++ b/data/info.olasagasti.revelation.desktop.in.in
@@ -7,7 +7,7 @@ Exec=revelation
 Icon=info.olasagasti.revelation
 Terminal=false
 Type=Application
-Categories=GNOME;GTK;Utility;
+Categories=GNOME;GTK;System;Security;
 StartupNotify=true
 MimeType=application/x-revelation;
 


### PR DESCRIPTION
Some distributions are rather strict about it: https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories