### PR TITLE
Add small Gtk.STOCK_COPY button near 'Password:' fields

### DIFF
--- a/src/lib/ui.py
+++ b/src/lib/ui.py
@@ -1453,6 +1453,14 @@ class EntryView(VBox):
                 widget.set_hexpand(True)
                 table.attach(widget, 1, rowindex, 1, 1)
 
+                if field.datatype == entry.DATATYPE_PASSWORD:
+                    button = Gtk.Button()
+                    image = Gtk.Image()
+                    image.set_from_stock(Gtk.STOCK_COPY, Gtk.IconSize.BUTTON)
+                    button.set_image(image)
+                    button.connect("clicked", lambda w: self.clipboard.set([field.value], True))
+                    table.attach(button, 2, rowindex, 1, 1)
+
         # notes
         label = Label("<span weight=\"bold\">%s</span>%s" % ((e.notes != "" and _("Notes: ") or ""),
                                                              util.escape_markup(e.notes)), Gtk.Justification.LEFT)


### PR DESCRIPTION
Increase usability: add a small button to copy a password.

Now:
* right click on 'Password:' field value (******)
* move mouse a bit down (but not too far);
* left-click 'Copy password'

With this change:
* left-click on 'copy' button on the right from 'Password:' (after ***** )

![Screenshot from 2021-01-31 04-29-18](https://user-images.githubusercontent.com/5078434/106368555-f2785900-637c-11eb-9b61-7338424b450c.png)



## Testing strategy
For any entry for your database, try using this new button instead of right-clicking on password, 'Copy password' from the menu. The new button should work the same, but much handy.

## Type of change
- ✅ New feature (change that adds functionality)
