### PR TITLE
Fix compatability with newer meson

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -59,7 +59,6 @@ rvl_appstreamdir = join_paths(rvl_datadir, 'metainfo')
 
 # Merge the translations with the MetaInfo file
 i18n.merge_file(
-  metainfo,
   input: metainfo + '.in',
   output: metainfo,
   po_dir: join_paths(meson.source_root(), 'po'),


### PR DESCRIPTION
Meson 0.60 and newer are completely unable to build revelation without
this fix, due to the deprecation of the positional argument used.

It can be removed without any change to the output.

This is an upstreaming of the patch required to make this build in gentoo:
https://github.com/gentoo/gentoo/commit/3496474bbc48fe59838518b04cf274c5c8b47ae7

Fixes Issue #87

## Screenshots
n/a

## Testing strategy
I was unable to build the software without this change. After the change, it loaded and
appeared to work normally.

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)