### PR TITLE
Fix Message dialog alignment

### DIFF
--- a/src/lib/dialog.py
+++ b/src/lib/dialog.py
@@ -192,7 +192,7 @@ class Message(Dialog):
         hbox.pack_start(self.contents, True, True, 0)
 
         label = ui.Label("<span size=\"larger\" weight=\"bold\">%s</span>\n\n%s" % (util.escape_markup(title), text))
-        label.set_justify(Gtk.Justification.FILL)
+        label.set_justify(Gtk.Justification.LEFT)
         label.set_selectable(True)
         label.set_max_width_chars(45)
         self.contents.pack_start(label, True, True, 0)


### PR DESCRIPTION
In e35a3a3 (Fix deprecated initialization, 2020-10-05), the alignment
was changed to fill rather than left align the text labels.  This
results in odd spacing between characters within the words of the label.

Use left alignment for label text in message dialogs.

Fixes #89

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/806319/188495002-d6ea990a-2253-4eb5-995c-b25928a7258b.png)

After:
![image](https://user-images.githubusercontent.com/806319/188495209-c303017f-fc6e-4dcc-bb3a-4be611a8f532.png)

## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)